### PR TITLE
chore: Update Cargo.toml add repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "deft"
 readme = "README.md"
 license = "MIT"
 description = "Cross platform ui framework"
+repository = "https://github.com/deft-ui/deft"
 
 version = "0.10.3"
 authors = ["KasonYang <me@kason.fun>"]

--- a/packages/deft-macros/Cargo.toml
+++ b/packages/deft-macros/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.3.1"
 edition = "2021"
 license = "MIT"
 description = "Deft macros"
+repository = "https://github.com/deft-ui/deft/"
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
To make it easier for potential contributors and automated tools to find the repository. More explanation: https://github.com/szabgab/rust-digger/issues/89